### PR TITLE
CartDrawer Styles & Closing Function

### DIFF
--- a/src/components/Buttons/ActionButton.js
+++ b/src/components/Buttons/ActionButton.js
@@ -2,9 +2,9 @@ import React from "react";
 
 import * as styles from "./ActionButton.module.css";
 
-const ActionButton = ({ buttonText, onClick, closeCart }) => {
+const ActionButton = ({ buttonText, onClick }) => {
   return (
-    <button className={styles.btnAction} onClick={closeCart}>
+    <button className={styles.btnAction} onClick={onClick}>
       {buttonText}
     </button>
   )

--- a/src/components/Buttons/ActionButton.js
+++ b/src/components/Buttons/ActionButton.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+import * as styles from "./ActionButton.module.css";
+
+const ActionButton = ({ buttonText, onClick, closeCart }) => {
+  return (
+    <button className={styles.btnAction} onClick={closeCart}>
+      {buttonText}
+    </button>
+  )
+}
+
+export default ActionButton;

--- a/src/components/Buttons/ActionButton.module.css
+++ b/src/components/Buttons/ActionButton.module.css
@@ -1,0 +1,19 @@
+.btn-action {
+  width: 50%;
+  height: 2.5rem;
+  margin: 2.25rem auto;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f6f6ff;
+  background-color: #141421;
+  font-weight: 400;
+  border-radius: 50px;
+}
+
+.btn-action:hover {
+  background-color: #6767ab;
+  transition: all 100ms ease-in-out;
+  cursor: pointer;
+}

--- a/src/components/Buttons/CloseButton.js
+++ b/src/components/Buttons/CloseButton.js
@@ -1,13 +1,12 @@
 import React from "react";
+import { AiOutlineClose } from "react-icons/ai";
 
 import * as styles from "./CloseButton.module.css";
 
 const CloseButton = ({ closeCart }) => {
 
   return (
-    <button className={styles.closeCartBtn} onClick={closeCart}>
-    Close
-  </button>
+    <AiOutlineClose className={styles.closeCartBtn} onClick={closeCart} />
   )
 }
 

--- a/src/components/Buttons/CloseButton.js
+++ b/src/components/Buttons/CloseButton.js
@@ -1,0 +1,14 @@
+import React from "react";
+
+import * as styles from "./CloseButton.module.css";
+
+const CloseButton = ({ closeCart }) => {
+
+  return (
+    <button className={styles.closeCartBtn} onClick={closeCart}>
+    Close
+  </button>
+  )
+}
+
+export default CloseButton;

--- a/src/components/Buttons/CloseButton.module.css
+++ b/src/components/Buttons/CloseButton.module.css
@@ -1,0 +1,3 @@
+.close-cart-btn {
+  
+}

--- a/src/components/Buttons/CloseButton.module.css
+++ b/src/components/Buttons/CloseButton.module.css
@@ -1,3 +1,3 @@
 .close-cart-btn {
-  
+  font-size: 1.5rem;
 }

--- a/src/components/Buttons/CloseButton.module.css
+++ b/src/components/Buttons/CloseButton.module.css
@@ -1,3 +1,4 @@
 .close-cart-btn {
   font-size: 1.5rem;
+  cursor: pointer;
 }

--- a/src/components/Layout/CartDrawer/Sections/CartHeader.js
+++ b/src/components/Layout/CartDrawer/Sections/CartHeader.js
@@ -5,7 +5,8 @@ import * as styles from "./CartHeader.module.css";
 const CartHeader = ({ closeCart }) => {
   return (
     <div className={styles.cartHeader}>
-      <span>Shopping Cart</span>
+      <div></div>
+      <h1><span>Shopping Bag</span></h1>
       <button className={styles.closeCartBtn} onClick={closeCart}>
         Close
       </button>

--- a/src/components/Layout/CartDrawer/Sections/CartHeader.js
+++ b/src/components/Layout/CartDrawer/Sections/CartHeader.js
@@ -1,4 +1,5 @@
 import React from "react";
+import CloseButton from "../../../Buttons/CloseButton";
 //
 import * as styles from "./CartHeader.module.css";
 
@@ -7,9 +8,7 @@ const CartHeader = ({ closeCart }) => {
     <div className={styles.cartHeader}>
       <div></div>
       <h1><span>Shopping Bag</span></h1>
-      <button className={styles.closeCartBtn} onClick={closeCart}>
-        Close
-      </button>
+      <CloseButton closeCart={closeCart} />
     </div>
   );
 };

--- a/src/components/Layout/CartDrawer/Sections/CartHeader.module.css
+++ b/src/components/Layout/CartDrawer/Sections/CartHeader.module.css
@@ -3,11 +3,16 @@
   display: grid;
   grid-template-columns: 1fr 4fr 1fr;
   grid-template-rows: 1fr;
+  align-items: center;
   padding-top: 25px;
   width: 100%;
 }
 
-.cart-header span {
+.cart-header h1 {
+  margin: 0;
+}
+
+.cart-header h1 span {
   border-bottom: 1px solid;
 }
 

--- a/src/components/Layout/CartDrawer/Sections/CartHeader.module.css
+++ b/src/components/Layout/CartDrawer/Sections/CartHeader.module.css
@@ -1,9 +1,16 @@
 /* cart header */
 .cart-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 4fr 1fr;
+  grid-template-rows: 1fr;
   padding-top: 25px;
   width: 100%;
 }
+
+.cart-header span {
+  border-bottom: 1px solid;
+}
+
 .close-cart-btn {
   margin-left: auto;
   margin-right: 10px;

--- a/src/components/Layout/CartDrawer/Sections/CartProducts.js
+++ b/src/components/Layout/CartDrawer/Sections/CartProducts.js
@@ -64,8 +64,8 @@ const CartProducts = ({ products }) => {
           alt={product.name}
         />
         <div className={styles.productDetails}>
-          <div>{product.name}</div>
-          <div>
+          <div className={styles.productName}>{product.name}</div>
+          <div className={styles.productPrice}>
             {product.discount
               ? formatPrice(product.price * (1 - product.discount))
               : formatPrice(product.price)}

--- a/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
+++ b/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
@@ -1,17 +1,17 @@
 /* product */
 .product-section {
   display: flex;
-  margin: 10px;
+  margin: 10% 5%;
 }
 .product-image {
-  width: 100px;
+  width: 30%;
 }
 /* product details */
 .product-details {
-  margin: 0 0 5px 5px;
+  margin: 2% 5%;
 }
 .product-details .actions {
-  margin-bottom: 5px;
+  margin-bottom: 7%;
 }
 .quantity-text {
   margin: 5px;

--- a/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
+++ b/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
@@ -32,6 +32,7 @@
 }
 
 .quantity-text {
+  font-size: 1.15rem;
   margin: 5px;
 }
 

--- a/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
+++ b/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
@@ -36,6 +36,7 @@
 }
 
 .quantity-button {
+  background-color: #A6A6B9;
 }
 
 .quantity-button:hover {

--- a/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
+++ b/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
@@ -3,27 +3,35 @@
   display: flex;
   margin: 10% 5%;
 }
+
 .product-image {
   width: 30%;
 }
+
 /* product details */
 .product-details {
   margin: 2% 5%;
 }
+
 .product-details .actions {
   margin-bottom: 7%;
 }
+
 .quantity-text {
   margin: 5px;
 }
+
 .quantity-button {
 }
+
 .quantity-button:hover {
   cursor: pointer;
 }
+
 .remove-button {
   text-decoration: underline;
 }
+
 .remove-button:hover {
   cursor: pointer;
 }

--- a/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
+++ b/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
@@ -10,11 +10,25 @@
 
 /* product details */
 .product-details {
-  margin: 2% 5%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin: 0 5%;
 }
 
 .product-details .actions {
   margin-bottom: 7%;
+}
+
+.product-name {
+  font-weight: 500;
+  margin-bottom: 5%;
+}
+
+.product-price {
+  font-weight: 600;
+  margin-bottom: 5%;
 }
 
 .quantity-text {
@@ -29,6 +43,7 @@
 }
 
 .remove-button {
+  font-size: 0.8rem;
   text-decoration: underline;
 }
 

--- a/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
+++ b/src/components/Layout/CartDrawer/Sections/CartProducts.module.css
@@ -38,6 +38,12 @@
 
 .quantity-button {
   background-color: #A6A6B9;
+  font-size: 1.15rem;
+  line-height: 1.15rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  padding: 0;
+  border: 1px solid #141421;
 }
 
 .quantity-button:hover {

--- a/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.js
+++ b/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.js
@@ -7,7 +7,7 @@ const EmptyCartMessage = ({ closeCart }) => {
   return (
     <div className={styles.root}>
       <div className={styles.msg}>Your bag is currently empty.</div>
-      <ActionButton buttonText="Continue Shopping" closeCart={closeCart} />
+      <ActionButton buttonText="Continue Shopping" onClick={closeCart} />
     </div>
   );
 };

--- a/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.js
+++ b/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.js
@@ -5,7 +5,7 @@ import * as styles from "./EmptyCartMessage.module.css";
 const EmptyCartMessage = ({ closeCart }) => {
   return (
     <div className={styles.root}>
-      <div className={styles.msg}>Your cart is currently empty</div>
+      <div className={styles.msg}>Your bag is currently empty.</div>
       <button className={styles.btn} onClick={closeCart}>
         Continue shopping
       </button>

--- a/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.js
+++ b/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.js
@@ -1,4 +1,5 @@
 import React from "react";
+import ActionButton from "../../../Buttons/ActionButton";
 //
 import * as styles from "./EmptyCartMessage.module.css";
 
@@ -6,9 +7,7 @@ const EmptyCartMessage = ({ closeCart }) => {
   return (
     <div className={styles.root}>
       <div className={styles.msg}>Your bag is currently empty.</div>
-      <button className={styles.btn} onClick={closeCart}>
-        Continue shopping
-      </button>
+      <ActionButton buttonText="Continue Shopping" closeCart={closeCart} />
     </div>
   );
 };

--- a/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.module.css
+++ b/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.module.css
@@ -1,6 +1,29 @@
 .root {
+  text-align: center;
 }
+
 .msg {
+  padding: 2.25rem;
+  font-size: 1.15rem;
+  font-weight: 300;
 }
+
 .btn {
+  width: 50%;
+  height: 2.5rem;
+  margin: 2.25rem auto;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f6f6ff;
+  background-color: #141421;
+  font-weight: 400;
+  border-radius: 50px;
+}
+
+.btn:hover {
+  background-color: #6767ab;
+  transition: all 100ms ease-in-out;
+  cursor: pointer;
 }

--- a/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.module.css
+++ b/src/components/Layout/CartDrawer/Sections/EmptyCartMessage.module.css
@@ -8,22 +8,3 @@
   font-weight: 300;
 }
 
-.btn {
-  width: 50%;
-  height: 2.5rem;
-  margin: 2.25rem auto;
-  padding: 1rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #f6f6ff;
-  background-color: #141421;
-  font-weight: 400;
-  border-radius: 50px;
-}
-
-.btn:hover {
-  background-color: #6767ab;
-  transition: all 100ms ease-in-out;
-  cursor: pointer;
-}

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.js
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.js
@@ -1,6 +1,7 @@
 import React from "react";
-import { Link } from "gatsby";
+import { Link, navigate } from "gatsby";
 //
+import ActionButton from "../../../Buttons/ActionButton";
 import { formatPrice } from "../../../../lib/helpers";
 //
 import * as styles from "./OrderSummary.module.css";
@@ -28,11 +29,14 @@ const OrderSummary = ({ cart, closeCart }) => {
         ))}
       </div>
       <hr />
-      <div className={styles.btnContainer}>
-        <Link to="/checkout" className={styles.btn} onClick={closeCart} >
-          Proceed with Order
-        </Link>
-      </div>
+      <ActionButton 
+        buttonText="Proceed with Order" 
+        onClick={() => {
+          navigate("/checkout");
+          closeCart();
+        }}
+      >
+      </ActionButton>
     </div>
   );
 };

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.js
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.js
@@ -8,17 +8,17 @@ import * as styles from "./OrderSummary.module.css";
 
 const OrderSummary = ({ cart, closeCart }) => {
   const orderSummaryDetails = [
-    ["# of Items:", cart.totalQuantity],
+    ["# of Items", cart.totalQuantity],
     ["Subtotal", formatPrice(cart.totalPrice)],
-    ["Shipping:", "FREE!"],
-    ["Estimated Tax:", "Calculated at Checkout"],
-    ["Total:", formatPrice(cart.totalPrice)],
+    ["Shipping", "FREE!"],
+    ["Estimated Tax", "Calculated at Checkout"],
+    ["Total", formatPrice(cart.totalPrice)],
   ];
 
   return (
     <div className={styles.orderSummary}>
-      <div className={styles.title}>Order Summary</div>
-
+      <h2 className={styles.title}>Order Summary</h2>
+      <hr />
       <div className={styles.details}>
         {orderSummaryDetails.map((item, i) => (
           <div key={item[0]} className={styles.item}>
@@ -27,7 +27,7 @@ const OrderSummary = ({ cart, closeCart }) => {
           </div>
         ))}
       </div>
-
+      <hr />
       <div className={styles.btnContainer}>
         <Link to="/checkout" className={styles.btn} onClick={closeCart} >
           Proceed with Order

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.js
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, navigate } from "gatsby";
+import { navigate } from "gatsby";
 //
 import ActionButton from "../../../Buttons/ActionButton";
 import { formatPrice } from "../../../../lib/helpers";

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.js
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.js
@@ -29,14 +29,7 @@ const OrderSummary = ({ cart, closeCart }) => {
         ))}
       </div>
       <hr />
-      <ActionButton 
-        buttonText="Proceed with Order" 
-        onClick={() => {
-          navigate("/checkout");
-          closeCart();
-        }}
-      >
-      </ActionButton>
+
     </div>
   );
 };

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.js
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.js
@@ -7,12 +7,12 @@ import * as styles from "./OrderSummary.module.css";
 
 const OrderSummary = ({ cart, closeCart }) => {
   const orderSummaryDetails = [
-    ["# of Items", cart.totalQuantity],
     ["Subtotal", formatPrice(cart.totalPrice)],
     ["Shipping", "FREE!"],
     ["Estimated Tax", "Calculated at Checkout"],
-    ["Total", formatPrice(cart.totalPrice)],
   ];
+
+  const orderTotal = ["Total", formatPrice(cart.totalPrice)];
 
   return (
     <div className={styles.orderSummary}>
@@ -27,7 +27,12 @@ const OrderSummary = ({ cart, closeCart }) => {
         ))}
       </div>
       <hr />
-
+      <div className={styles.details}>
+      <div className={styles.total}>
+        <span className={styles.left}>{orderTotal[0]}</span>
+        <span className={styles.right}>{orderTotal[1]}</span>
+      </div>
+      </div>
     </div>
   );
 };

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.js
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.js
@@ -1,7 +1,5 @@
 import React from "react";
-import { navigate } from "gatsby";
 //
-import ActionButton from "../../../Buttons/ActionButton";
 import { formatPrice } from "../../../../lib/helpers";
 //
 import * as styles from "./OrderSummary.module.css";

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
@@ -2,8 +2,8 @@
 .order-summary {
   background-color: #FAFAFF;
   border: 1px solid #A6A6B9;
-  margin: 10px;
-  padding: 20px;
+  margin: 5%;
+  padding: 10%;
 }
 
 .order-summary .title {

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
@@ -3,7 +3,7 @@
   background-color: #FAFAFF;
   border: 1px solid #A6A6B9;
   margin: 5%;
-  padding: 10%;
+  padding: 5%;
 }
 
 .order-summary .title {

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
@@ -12,6 +12,7 @@
 }
 
 .order-summary .details .item {
+  font-size: 0.8rem;
 }
 
 .order-summary .details .left {

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
@@ -1,13 +1,14 @@
 /* order summary */
 .order-summary {
-  border: 1px dotted grey;
+  background-color: #FAFAFF;
+  border: 1px solid #A6A6B9;
   margin: 10px;
   padding: 20px;
 }
 
 .order-summary .title {
   text-align: center;
-  font-weight: bold;
+  margin: 0;
 }
 
 .order-summary .details .item {
@@ -30,4 +31,8 @@
 }
 .order-summary .btn-container :hover {
   cursor: pointer;
+}
+
+hr {
+  color: #A6A6B9;
 }

--- a/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
+++ b/src/components/Layout/CartDrawer/Sections/OrderSummary.module.css
@@ -12,7 +12,12 @@
 }
 
 .order-summary .details .item {
-  font-size: 0.8rem;
+  font-size: 0.9rem;
+}
+
+.order-summary .details .total {
+  font-size: 1.25rem;
+  font-weight: 600;
 }
 
 .order-summary .details .left {

--- a/src/components/Layout/CartDrawer/index.js
+++ b/src/components/Layout/CartDrawer/index.js
@@ -31,8 +31,7 @@ const CartDrawer = ({ closeCart }) => {
                 navigate("/checkout");
                 closeCart();
               }}
-            >
-            </ActionButton>
+            />
           </>
         ) : (
           <EmptyCartMessage closeCart={closeCart} />

--- a/src/components/Layout/CartDrawer/index.js
+++ b/src/components/Layout/CartDrawer/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { navigate } from "gatsby";
 //
 import { useSelector } from "react-redux";
 import { cartSelector } from "../../../state/cartSlice";
@@ -7,6 +8,7 @@ import CartHeader from "./Sections/CartHeader";
 import CartProducts from "./Sections/CartProducts";
 import OrderSummary from "./Sections/OrderSummary";
 import EmptyCartMessage from "./Sections/EmptyCartMessage";
+import ActionButton from "../../Buttons/ActionButton";
 //
 import * as styles from "./index.module.css";
 
@@ -23,6 +25,14 @@ const CartDrawer = ({ closeCart }) => {
               <CartProducts products={cart.items} />
             </div>
             <OrderSummary cart={cart} closeCart={closeCart} />
+            <ActionButton 
+              buttonText="Proceed with Order" 
+              onClick={() => {
+                navigate("/checkout");
+                closeCart();
+              }}
+            >
+            </ActionButton>
           </>
         ) : (
           <EmptyCartMessage closeCart={closeCart} />

--- a/src/components/Layout/CartDrawer/index.js
+++ b/src/components/Layout/CartDrawer/index.js
@@ -12,12 +12,21 @@ import ActionButton from "../../Buttons/ActionButton";
 //
 import * as styles from "./index.module.css";
 
-const CartDrawer = ({ closeCart }) => {
+const CartDrawer = ({ closeCart, showCart }) => {
   const cart = useSelector(cartSelector);
 
   return (
-    <div className={styles.root} onClick={closeCart}>
-      <div className={styles.drawerContainer} onClick={e => e.stopPropagation()}>
+    <div 
+      className={styles.root} 
+      onClick={closeCart}
+    >
+      <div 
+        className={
+          showCart
+          ? `${styles.drawerContainer} ${styles.open}`
+          : `${styles.drawerContainer} ${styles.closed}`
+        } 
+        onClick={e => e.stopPropagation()}>
         <CartHeader closeCart={closeCart} />
         {cart.totalQuantity > 0 ? (
           <>

--- a/src/components/Layout/CartDrawer/index.js
+++ b/src/components/Layout/CartDrawer/index.js
@@ -26,6 +26,7 @@ const CartDrawer = ({ closeCart }) => {
             </div>
             <OrderSummary cart={cart} closeCart={closeCart} />
             <ActionButton 
+              className={styles.actionButton}
               buttonText="Proceed with Order" 
               onClick={() => {
                 navigate("/checkout");

--- a/src/components/Layout/CartDrawer/index.js
+++ b/src/components/Layout/CartDrawer/index.js
@@ -19,6 +19,8 @@ const CartDrawer = ({ closeCart, showCart }) => {
     <div 
       className={styles.root} 
       onClick={closeCart}
+      onKeyPress={closeCart}
+      aria-hidden="true"
     >
       <div 
         className={
@@ -26,7 +28,10 @@ const CartDrawer = ({ closeCart, showCart }) => {
           ? `${styles.drawerContainer} ${styles.open}`
           : `${styles.drawerContainer} ${styles.closed}`
         } 
-        onClick={e => e.stopPropagation()}>
+        onClick={e => e.stopPropagation()}
+        onKeyPress={e => e.stopPropagation()}
+        role="dialog"
+      >
         <CartHeader closeCart={closeCart} />
         {cart.totalQuantity > 0 ? (
           <>

--- a/src/components/Layout/CartDrawer/index.js
+++ b/src/components/Layout/CartDrawer/index.js
@@ -17,7 +17,6 @@ const CartDrawer = ({ closeCart }) => {
     <div className={styles.root}>
       <div className={styles.drawerContainer}>
         <CartHeader closeCart={closeCart} />
-        <hr />
         {cart.totalQuantity > 0 ? (
           <>
             <CartProducts products={cart.items} />

--- a/src/components/Layout/CartDrawer/index.js
+++ b/src/components/Layout/CartDrawer/index.js
@@ -16,8 +16,8 @@ const CartDrawer = ({ closeCart }) => {
   const cart = useSelector(cartSelector);
 
   return (
-    <div className={styles.root}>
-      <div className={styles.drawerContainer}>
+    <div className={styles.root} onClick={closeCart}>
+      <div className={styles.drawerContainer} onClick={e => e.stopPropagation()}>
         <CartHeader closeCart={closeCart} />
         {cart.totalQuantity > 0 ? (
           <>

--- a/src/components/Layout/CartDrawer/index.js
+++ b/src/components/Layout/CartDrawer/index.js
@@ -24,7 +24,7 @@ const CartDrawer = ({ closeCart }) => {
             <div className={styles.productsContainer}>
               <CartProducts products={cart.items} />
             </div>
-            <OrderSummary cart={cart} closeCart={closeCart} />
+            <OrderSummary cart={cart} />
             <ActionButton 
               className={styles.actionButton}
               buttonText="Proceed with Order" 

--- a/src/components/Layout/CartDrawer/index.js
+++ b/src/components/Layout/CartDrawer/index.js
@@ -19,7 +19,9 @@ const CartDrawer = ({ closeCart }) => {
         <CartHeader closeCart={closeCart} />
         {cart.totalQuantity > 0 ? (
           <>
-            <CartProducts products={cart.items} />
+            <div className={styles.productsContainer}>
+              <CartProducts products={cart.items} />
+            </div>
             <OrderSummary cart={cart} closeCart={closeCart} />
           </>
         ) : (

--- a/src/components/Layout/CartDrawer/index.module.css
+++ b/src/components/Layout/CartDrawer/index.module.css
@@ -28,7 +28,7 @@
 
 .products-container {
   max-height: 50vh;
-  overflow: scroll;
+  overflow-y: scroll;
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/components/Layout/CartDrawer/index.module.css
+++ b/src/components/Layout/CartDrawer/index.module.css
@@ -31,8 +31,14 @@
   overflow-y: scroll;
 }
 
+@media screen and (min-width: 756px) {
+  .drawer-container {
+    width: 50vw;
+  }
+}
+
 @media screen and (min-width: 1024px) {
   .drawer-container {
-  width: 50%;
+  width: 40vw;
   }
 }

--- a/src/components/Layout/CartDrawer/index.module.css
+++ b/src/components/Layout/CartDrawer/index.module.css
@@ -1,21 +1,11 @@
 .root {
   position: fixed;
+  top: 0;
   width: 100vw;
   height: 100vh;
   overflow: hidden;
   background-color: rgba(0, 0, 0, 0.5);
   z-index: 2;
-}
-
-@media (max-width: 700px) {
-  .root {
-    top: 54px;
-  }
-}
-@media (min-width: 701px) and (min-height: 600px) {
-  .root {
-    top: 72px;
-  }
 }
 
 .drawer-container {

--- a/src/components/Layout/CartDrawer/index.module.css
+++ b/src/components/Layout/CartDrawer/index.module.css
@@ -18,9 +18,15 @@
 }
 
 .drawer-container {
-  width: 50%;
+  width: 100%;
   max-width: 500px;
   height: 100%;
   margin-left: auto;
   background-color: white;
+}
+
+@media screen and (min-width: 1024px) {
+  .drawer-container {
+  width: 50%;
+  }
 }

--- a/src/components/Layout/CartDrawer/index.module.css
+++ b/src/components/Layout/CartDrawer/index.module.css
@@ -2,6 +2,7 @@
   position: fixed;
   width: 100vw;
   height: 100vh;
+  overflow: hidden;
   background-color: rgba(0, 0, 0, 0.5);
   z-index: 2;
 }
@@ -18,8 +19,12 @@
 }
 
 .drawer-container {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  right: 0;
+  bottom: 0;
   width: 100%;
-  max-width: 500px;
   height: 100%;
   margin-left: auto;
   background-color: #F6F6FF;
@@ -31,9 +36,16 @@
   overflow-y: scroll;
 }
 
-@media screen and (min-width: 756px) {
+.action-button {
+  position: absolute;
+  bottom: 3vh;
+  margin-bottom: 5%;
+}
+
+@media screen and (min-width: 768px) {
   .drawer-container {
     width: 50vw;
+    max-width: 500px;
   }
 }
 

--- a/src/components/Layout/CartDrawer/index.module.css
+++ b/src/components/Layout/CartDrawer/index.module.css
@@ -22,7 +22,7 @@
   max-width: 500px;
   height: 100%;
   margin-left: auto;
-  background-color: white;
+  background-color: #F6F6FF;
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/components/Layout/CartDrawer/index.module.css
+++ b/src/components/Layout/CartDrawer/index.module.css
@@ -23,6 +23,12 @@
   height: 100%;
   margin-left: auto;
   background-color: #F6F6FF;
+
+}
+
+.products-container {
+  max-height: 50vh;
+  overflow: scroll;
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/components/Layout/CartDrawer/index.module.css
+++ b/src/components/Layout/CartDrawer/index.module.css
@@ -18,7 +18,21 @@
   height: 100%;
   margin-left: auto;
   background-color: #F6F6FF;
+  z-index: 1;
+  opacity: 0;
+}
 
+.open {
+  z-index: 2;
+  opacity: 1;
+  transition: opacity 0.3s ease-in 0.1s;
+}
+
+.closed {
+  z-index: -1;
+  opacity: 0;
+  transition: opacity 0.2s ease-out 0.1s;
+  animation: close-overlay 0.3s;
 }
 
 .products-container {
@@ -32,15 +46,100 @@
   margin-bottom: 5%;
 }
 
+@keyframes close-overlay {
+  0% {
+    z-index: 2;
+  }
+  50% {
+    z-index: 2;
+  }
+  75% {
+    z-index: 2;
+  }
+  90% {
+    z-index: 1;
+  }
+  100% {
+    z-index: -1;
+
+  }
+}
+
 @media screen and (min-width: 768px) {
   .drawer-container {
+    width: 0;
+  }
+
+  .open {
     width: 50vw;
     max-width: 500px;
+    transition: none;
+    animation: slide-in 0.2s;
+  }
+
+  .closed {
+    width: 0;
+    animation: slide-out 0.2s;
+  }
+  
+  @keyframes slide-in {
+    0% { 
+      width: 0;
+    }
+    50% {
+      width: 25vw;
+    }
+    100% {
+      width: 50vw;
+    }
+  }
+
+  @keyframes slide-out {
+    0% {
+      width: 50vw;
+      z-index: 2;
+    }
+    50% {
+      width: 25vw;
+      z-index: 2;
+    }
+    100% {
+      width: 0;
+      z-index: -1;
+    }
   }
 }
 
 @media screen and (min-width: 1024px) {
-  .drawer-container {
-  width: 40vw;
+
+  .open {
+    width: 40vw;
+  }
+
+  @keyframes slide-in {
+    0% { 
+      width: 0;
+    }
+    50% {
+      width: 20vw;
+    }
+    100% {
+      width: 40vw;
+    }
+  }
+
+  @keyframes slide-out {
+    0% {
+      width: 40vw;
+      z-index: 2;
+    }
+    50% {
+      width: 20vw;
+      z-index: 2;
+    }
+    100% {
+      width: 0;
+      z-index: -1;
+    }
   }
 }

--- a/src/components/Layout/Header/Sections/CartButton.js
+++ b/src/components/Layout/Header/Sections/CartButton.js
@@ -4,11 +4,13 @@ import { FaShoppingBag } from "react-icons/fa";
 import CartQuantity from "./CartQuantity";
 import * as styles from "./CartButton.module.css";
 
-const CartButton = ({ toggleCart }) => {
+const CartButton = ({ toggleCart, setShowMenu }) => {
 
   return (
     <div className={styles.cartButtonContainer}>
-      <FaShoppingBag className={styles.menuIcon} onClick={toggleCart} /> 
+      <FaShoppingBag 
+        className={styles.menuIcon} 
+        onClick={toggleCart} /> 
       <CartQuantity />
     </div>
   );

--- a/src/components/Layout/Header/index.js
+++ b/src/components/Layout/Header/index.js
@@ -10,11 +10,18 @@ const Header = ({ showMenu, toggleCart, toggleMenu }) => {
 
   return (
     <header className={styles.header}>
-      <HamburgerMenu className={styles.menuIcon} showMenu={showMenu} toggleMenu={toggleMenu} />
+      <HamburgerMenu 
+        className={styles.menuIcon} 
+        showMenu={showMenu} 
+        toggleMenu={toggleMenu}
+      />
       <Link to='/' className={styles.homeLink}>
         <p>EcommStore</p>
       </Link>
-      <CartButton className={styles.menuIcon} toggleCart={toggleCart} />
+      <CartButton 
+        className={styles.menuIcon} 
+        toggleCart={toggleCart}
+      />
     </header>
   );
 };

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -15,6 +15,9 @@ const Layout = ({ children }) => {
 
   const toggleCart = () => {
     setShowCart(!showCart);
+    if (showMenu) {
+      setShowMenu(false);
+    }
   };
 
   // Local state to handle showing menu modal/overlay
@@ -22,6 +25,9 @@ const Layout = ({ children }) => {
   
   const toggleMenu = () => {
     setShowMenu(!showMenu);
+    if (showCart) {
+      setShowCart(false);
+    }
   };
 
   return (

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -29,7 +29,7 @@ const Layout = ({ children }) => {
       <Header showMenu={showMenu} toggleCart={toggleCart} toggleMenu={toggleMenu} />
       <MenuModal showMenu={showMenu} closeMenu={toggleMenu} toggleMenu={toggleMenu}/>
       {/* REPLACE with Cart component */}
-      {showCart && <CartDrawer closeCart={toggleCart} />}
+      {showCart && <CartDrawer closeCart={toggleCart} showCart={showCart} />}
       {children}
     </>
   );

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,24 @@ body {
   color: #141421;
 }
 
+h1 {
+  font-family: 'Varela', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 400;
+}
+
+h2 {
+  font-family: 'Varela', sans-serif;
+  font-size: 1.25rem;
+  font-weight: 400;
+}
+
+h3 {
+  font-family: 'Noto Sans', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 500;
+}
+
 /* Override Default Button Styles */
 
 button {


### PR DESCRIPTION
Applied styling to the `CartDrawer` and its subcomponents and created a couple of reusable components.

**Components modified:**
- `CartDrawer` and all its children
- `Layout`
- `Header`

**Components created:**
- `ActionButton`
- `CloseButton`

**Notes:**
- I did end up implementing the modal-closing actions on this branch. Calling `setState` within both of the toggle functions seemed the most straight-forward way to do this without needing to pass props around everywhere—technically it is having those toggle functions do more than one thing, which I know is best avoided, but in this case I'm not sure what the downside would be. (You'll also notice the menu is inaccessible when the CartDrawer is open, so that function is only really necessary one-way.)
- Removed the "# of items" line from the `OrderSummary` because, while it's been helpful during development, this wouldn't normally appear in a summary table.