### PR TITLE
Remove default link styling in product cards

### DIFF
--- a/src/page-components/ProductsPage/Sections/ProductCard.js
+++ b/src/page-components/ProductsPage/Sections/ProductCard.js
@@ -16,8 +16,8 @@ const ProductCard = ({ product }) => {
         />
       </Link>
       <div className={styles.detailsActions}>
-        <Link to={`/products/${product.productId}`}>
-          <h2 className={styles.productName}>{product.name}</h2>
+        <Link className={styles.productName} to={`/products/${product.productId}`}>
+          <h2>{product.name}</h2>
         </Link>
         <ProductPrice product={product} />
       </div>

--- a/src/page-components/ProductsPage/Sections/ProductCard.module.css
+++ b/src/page-components/ProductsPage/Sections/ProductCard.module.css
@@ -31,6 +31,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-bottom: 1rem;
 }
 
 .product-name {

--- a/src/page-components/ProductsPage/Sections/ProductCard.module.css
+++ b/src/page-components/ProductsPage/Sections/ProductCard.module.css
@@ -35,4 +35,6 @@
 
 .product-name {
   margin-bottom: 0;
+  text-decoration: none;
+  color: #141421;
 }

--- a/src/page-components/ProductsPage/Sections/ProductPrice.js
+++ b/src/page-components/ProductsPage/Sections/ProductPrice.js
@@ -5,13 +5,13 @@ import * as styles from "./ProductPrice.module.css";
 const ProductPrice = ({ product }) => {
   return (
     <div className={styles.pricesContainer}>
-      <h2 className={styles.price}>
+      <span className={styles.price}>
         {product.discount > 0
           ? formatPrice(product.price * (1 - product.discount))
           : formatPrice(product.price)}
-      </h2>
+      </span>
       {product.discount > 0 && (
-        <h2 className={styles.discountPrice}>{formatPrice(product.price)}</h2>
+        <span className={styles.discountPrice}>{formatPrice(product.price)}</span>
       )}
     </div>
   );

--- a/src/page-components/ProductsPage/Sections/ProductPrice.module.css
+++ b/src/page-components/ProductsPage/Sections/ProductPrice.module.css
@@ -7,11 +7,14 @@
 }
 
 .price {
+  font-size: 1.3rem;
   font-weight: bold;
 }
 
 .discount-price {
-  color: gray;
+  color: #A6A6B9;
   text-decoration: line-through;
-  font-size: 1.3rem;
+  font-size: 1.2rem;
+  font-weight: 300;
+  margin-left: 1rem;
 }


### PR DESCRIPTION
Applied the product name styles to the Gatsby Link rather than the inner H2 for easier styling and made a few other minor design changes within the `ProductCard` and `ProductPrice` components.